### PR TITLE
Use proxy to get cacert.pem file

### DIFF
--- a/authorizer.php
+++ b/authorizer.php
@@ -954,7 +954,7 @@ if ( ! class_exists( 'WP_Plugin_Authorizer' ) ) {
 			$time_90_days_ago = time() - $time_90_days;
 			if ( ! file_exists( $cacert_path ) || filemtime( $cacert_path ) < $time_90_days_ago ) {
                                 $caUrl = 'https://curl.haxx.se/ca/cacert.pem';
-                                if ( ! defined( WP_PROXY_HOST ) ) {
+                                if ( ! defined( 'WP_PROXY_HOST' ) ) {
                                         $cacert_contents = file_get_contents( $caUrl );
                                 } else {
                                         $proxyurl = "tcp://" . WP_PROXY_HOST . ":" . WP_PROXY_PORT;

--- a/authorizer.php
+++ b/authorizer.php
@@ -953,7 +953,20 @@ if ( ! class_exists( 'WP_Plugin_Authorizer' ) ) {
 			$time_90_days = 90 * 24 * 60 * 60; // days * hours * minutes * seconds
 			$time_90_days_ago = time() - $time_90_days;
 			if ( ! file_exists( $cacert_path ) || filemtime( $cacert_path ) < $time_90_days_ago ) {
-				$cacert_contents = file_get_contents( 'http://curl.haxx.se/ca/cacert.pem' );
+                                $caUrl = 'https://curl.haxx.se/ca/cacert.pem';
+                                if ( ! defined( WP_PROXY_HOST ) ) {
+                                        $cacert_contents = file_get_contents( $caUrl );
+                                } else {
+                                        $proxyurl = "tcp://" . WP_PROXY_HOST . ":" . WP_PROXY_PORT;
+                                        $domain = parse_url( $caUrl, PHP_URL_HOST );
+                                        $opts = array(
+                                                'http' => array( 'proxy' => $proxyurl ),
+                                                'ssl' => array( 'SNI_enabled' => true, 'SNI_server_name' => $domain )
+                                        );
+                                        $context = stream_context_create($opts);
+                                        $cacert_contents = file_get_contents( $caUrl, false, $context );
+                                }
+
 				if ( $cacert_contents !== false ) {
 					file_put_contents( $cacert_path, $cacert_contents );
 				} else {


### PR DESCRIPTION
Hello,
My wordpress installation are behind a proxy. Some mouths after installing Authorizer, il get error 500 while connectiong to worpdress. I found that Authorizer get a file on Internet without using proxy. 
I make this patch. If Wordpress installation is behind a proxy. Adding proxy context to get CA certs from Mozilla. Also it get cacert.pem with secure url (https).

Could you please add this to your next release of Authorizer. Thanks