### PR TITLE
Prevent error message when login form is first shown.

### DIFF
--- a/authorizer.php
+++ b/authorizer.php
@@ -419,6 +419,9 @@ if ( ! class_exists( 'WP_Plugin_Authorizer' ) ) {
 						wp_lostpassword_url()
 					)
 				);
+			} else if ( ! $is_login_attempt )
+				// Prevent error message when login form is first shown
+				return $user;
 			}
 
 			// Start external authentication.


### PR DESCRIPTION
Authorizes tries to authenticate user even when it has determined that the request in question is not a login attempt. This shows error message "Username and password required" on first show of login form (wp-login.php).

At least this happens with 4.6.1 and LDAP authentication enabled in Authorizer.