### PR TITLE
Fix Service URL

### DIFF
--- a/authorizer.php
+++ b/authorizer.php
@@ -1129,7 +1129,7 @@ if ( ! class_exists( 'WP_Plugin_Authorizer' ) ) {
 				file_put_contents( $cacert_path, $cacert_contents );
 			}
 			phpCAS::setCasServerCACert( $cacert_path );
-
+			phpCAS::setFixedServiceURL(site_url() . '/wp-login.php?external=cas');
 			// Authenticate against CAS
 			try {
 				phpCAS::forceAuthentication();


### PR DESCRIPTION
Added line to ensure that the current sites URL is being taken and not the referral. We were having issues where sites hosted Pantheon was sending users back to their servers instead of the sites url. 

This way CAS doesn't have to assume where the request is coming from based on the referral either. 