### PR TITLE
Specific use of TLS flag

### DIFF
--- a/languages/authorizer.pot
+++ b/languages/authorizer.pot
@@ -291,7 +291,7 @@ msgid "LDAP Port"
 msgstr ""
 
 #: authorizer.php:2423 authorizer.php:4426
-msgid "Secure Connection (TLS)"
+msgid "Use TLS"
 msgstr ""
 
 #: authorizer.php:2430 authorizer.php:4430


### PR DESCRIPTION
Since ldap_tls and ldaps are two different things both providing a secure connection the use if "Secure Connection (TLS)" is not really accurate and kind of misleading. My proposed Change would be to just rename the field to Use TLS with the note that you, should not use it when using ldaps