### PR TITLE
Update authorizer.php

### DIFF
--- a/authorizer.php
+++ b/authorizer.php
@@ -587,6 +587,11 @@ if ( ! class_exists( 'WP_Plugin_Authorizer' ) ) {
 				}
 			}
 
+			// We'll track how this user was authenticated in user meta.
+			if ( $user ) {
+				update_user_meta( $user->ID, 'authenticated_by', $authenticated_by );
+			}
+
 			// Check this external user's access against the access lists
 			// (pending, approved, blocked).
 			$result = $this->check_user_access( $user, $externally_authenticated_emails, $result );
@@ -599,11 +604,6 @@ if ( ! class_exists( 'WP_Plugin_Authorizer' ) ) {
 			// If we have a valid user from check_user_access(), log that user in.
 			if ( get_class( $result ) === 'WP_User' ) {
 				$user = $result;
-			}
-
-			// We'll track how this user was authenticated in user meta.
-			if ( $user ) {
-				update_user_meta( $user->ID, 'authenticated_by', $authenticated_by );
 			}
 
 			// If we haven't exited yet, we have a valid/approved user, so authenticate them.


### PR DESCRIPTION
Update user meta before checking user access. Why ? because if you try to authenticate with a user not yet approved, you get the message : 
"You’re not currently allowed to view this site"
Then, if you click on the back button, it try to disconnect you, but in fact, php session is not destroyed, you are still connected and you can not log with another user unless you destroy phpsessid cookie.