### PR TITLE
Retrieval of additional LDAP attributes

### DIFF
--- a/src/authorizer/class-authentication.php
+++ b/src/authorizer/class-authentication.php
@@ -682,6 +682,15 @@ class Authentication extends Static_Instance {
 			array_push( $ldap_attributes_to_retrieve, Helper::lowercase( $auth_settings['ldap_attr_email'] ) );
 		}
 
+		/**
+		 * Specify additional LDAP user attributes to retrieve during authentication.
+		 * May be used by plugins in `authorizer_user_register`.
+		 *
+		 * @param array $attributes LDAP attributes to retrieve in addition to first name, last name and email.
+		 */
+		$additional_ldap_attributes_to_retrieve = apply_filters( 'authorizer_additional_ldap_attributes_to_retrieve', array() );
+		$ldap_attributes_to_retrieve = array_merge($ldap_attributes_to_retrieve, $additional_ldap_attributes_to_retrieve);
+
 		// Create default LDAP search filter. If LDAP email attribute is provided,
 		// use (|(uid=$username)(mail=$username)) instead (so logins with either a
 		// username or an email address will work). Otherwise use (uid=$username).


### PR DESCRIPTION
It would be nice for other plugins to be able to utilize this plugin to retrieve additional LDAP attributes (e.g. upon registration / first login), e.g. to check for custom properties.

I've added a new filter hook `authorizer_additional_ldap_attributes_to_retrieve` in `custom_authenticate_ldap()` that allows to fill an array of additional LDAP attributes, which are added to the predefined `$ldap_attributes_to_retrieve` (first name, last name and email).