### PR TITLE
Add proxy selection capability

### DIFF
--- a/js/authorizer.js
+++ b/js/authorizer.js
@@ -1236,6 +1236,7 @@
 			cas_host: cas_host,
 			cas_port: cas_port,
 			cas_path: cas_path,
+			cas_method: cas_method,
 			cas_version: cas_version,
 			cas_attr_email: cas_attr_email,
 			cas_attr_first_name: cas_attr_first_name,

--- a/js/authorizer.js
+++ b/js/authorizer.js
@@ -399,6 +399,7 @@
 		var auth_settings_external_cas_host = $( '#auth_settings_cas_host' ).closest( 'tr' );
 		var auth_settings_external_cas_port = $( '#auth_settings_cas_port' ).closest( 'tr' );
 		var auth_settings_external_cas_path = $( '#auth_settings_cas_path' ).closest( 'tr' );
+		var auth_settings_external_cas_method = $( '#auth_settings_cas_method' ).closest( 'tr' );
 		var auth_settings_external_cas_version = $( '#auth_settings_cas_version' ).closest( 'tr' );
 		var auth_settings_external_cas_attr_email = $( '#auth_settings_cas_attr_email' ).closest( 'tr' );
 		var auth_settings_external_cas_attr_first_name = $( '#auth_settings_cas_attr_first_name' ).closest( 'tr' );
@@ -449,6 +450,7 @@
 		$( 'th, td', auth_settings_external_cas_host ).wrapInner( '<div class="animated_wrapper" />' );
 		$( 'th, td', auth_settings_external_cas_port ).wrapInner( '<div class="animated_wrapper" />' );
 		$( 'th, td', auth_settings_external_cas_path ).wrapInner( '<div class="animated_wrapper" />' );
+		$( 'th, td', auth_settings_external_cas_method ).wrapInner( '<div class="animated_wrapper" />' );
 		$( 'th, td', auth_settings_external_cas_version ).wrapInner( '<div class="animated_wrapper" />' );
 		$( 'th, td', auth_settings_external_cas_attr_email ).wrapInner( '<div class="animated_wrapper" />' );
 		$( 'th, td', auth_settings_external_cas_attr_first_name ).wrapInner( '<div class="animated_wrapper" />' );
@@ -527,6 +529,7 @@
 			animateOption( 'hide_immediately', auth_settings_external_cas_host );
 			animateOption( 'hide_immediately', auth_settings_external_cas_port );
 			animateOption( 'hide_immediately', auth_settings_external_cas_path );
+			animateOption( 'hide_immediately', auth_settings_external_cas_method );
 			animateOption( 'hide_immediately', auth_settings_external_cas_version );
 			animateOption( 'hide_immediately', auth_settings_external_cas_attr_email );
 			animateOption( 'hide_immediately', auth_settings_external_cas_attr_first_name );
@@ -618,6 +621,7 @@
 			animateOption( action, auth_settings_external_cas_host );
 			animateOption( action, auth_settings_external_cas_port );
 			animateOption( action, auth_settings_external_cas_path );
+			animateOption( action, auth_settings_external_cas_method );
 			animateOption( action, auth_settings_external_cas_version );
 			animateOption( action, auth_settings_external_cas_attr_email );
 			animateOption( action, auth_settings_external_cas_attr_first_name );
@@ -1165,6 +1169,7 @@
 		var cas_host = $( '#auth_settings_cas_host' ).val();
 		var cas_port = $( '#auth_settings_cas_port' ).val();
 		var cas_path = $( '#auth_settings_cas_path' ).val();
+		var cas_method = $( '#auth_settings_cas_method' ).val();
 		var cas_version = $( '#auth_settings_cas_version' ).val();
 		var cas_attr_email = $( '#auth_settings_cas_attr_email' ).val();
 		var cas_attr_first_name = $( '#auth_settings_cas_attr_first_name' ).val();

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Authorizer ===
-Contributors: figureone, the_magician, pkarjala, aargh-a-knot, elarequi, jojaba
+Contributors: figureone, the_magician, pkarjala, aargh-a-knot, elarequi, jojaba, slyraskal
 Tags: cas, ldap, google, google plus, login, authentication, authorization, access, education, limit login attempts, oauth
 Tested up to: 6.0
 Stable tag: trunk

--- a/src/authorizer/class-admin-page.php
+++ b/src/authorizer/class-admin-page.php
@@ -1133,7 +1133,7 @@ class Admin_Page extends Singleton {
 	 * Action: admin_head-index.php
 	 */
 	public function load_options_page() {
-		wp_enqueue_script( 'authorizer', plugins_url( 'js/authorizer.js', plugin_root() ), array( 'jquery-effects-shake' ), '3.3.3', true );
+		wp_enqueue_script( 'authorizer', plugins_url( 'js/authorizer.js', plugin_root() ), array( 'jquery-effects-shake' ), '3.4.1', true );
 		wp_localize_script(
 			'authorizer',
 			'authL10n',

--- a/src/authorizer/class-admin-page.php
+++ b/src/authorizer/class-admin-page.php
@@ -111,6 +111,7 @@ class Admin_Page extends Singleton {
 				<li>' . __( '<strong>CAS server hostname</strong>: Enter the hostname of the CAS server you authenticate against (e.g., authn.example.edu).', 'authorizer' ) . '</li>
 				<li>' . __( '<strong>CAS server port</strong>: Enter the port on the CAS server to connect to (e.g., 443).', 'authorizer' ) . '</li>
 				<li>' . __( '<strong>CAS server path/context</strong>: Enter the path to the login endpoint on the CAS server (e.g., /cas).', 'authorizer' ) . '</li>
+				<li>' . __( '<strong>CAS server method</strong>: Select the method to use when setting the CAS config (e.g.,"client" or "proxy")', 'authorizer' ) . '</li>
 				<li>' . __( "<strong>CAS attribute containing first name</strong>: Enter the CAS attribute that has the user's first name. When this user first logs in, their WordPress account will have their first name retrieved from CAS and added to their WordPress profile.", 'authorizer' ) . '</li>
 				<li>' . __( "<strong>CAS attribute containing last name</strong>: Enter the CAS attribute that has the user's last name. When this user first logs in, their WordPress account will have their last name retrieved from CAS and added to their WordPress profile.", 'authorizer' ) . '</li>
 				<li>' . __( '<strong>CAS attribute update</strong>: Select whether the first and last names retrieved from CAS should overwrite any value the user has entered in the first and last name fields in their WordPress profile. If this is not set, this only happens the first time they log in.', 'authorizer' ) . '</li>
@@ -529,6 +530,13 @@ class Admin_Page extends Singleton {
 			'auth_settings_external'
 		);
 		add_settings_field(
+			'auth_settings_cas_method',
+			__( 'CAS server method', 'authorizer' ),
+			array( Cas::get_instance(), 'print_select_cas_method' ),
+			'authorizer',
+			'auth_settings_external'
+		);
+		add_settings_field(
 			'auth_settings_cas_version',
 			__( 'CAS server protocol', 'authorizer' ),
 			array( Cas::get_instance(), 'print_select_cas_version' ),
@@ -928,6 +936,10 @@ class Admin_Page extends Singleton {
 						<tr>
 							<th scope="row"><?php esc_html_e( 'CAS server path/context', 'authorizer' ); ?></th>
 							<td><?php $cas->print_text_cas_path( array( 'context' => Helper::NETWORK_CONTEXT ) ); ?></td>
+						</tr>
+						<tr>
+							<th scope="row"><?php esc_html_e( 'CAS server method', 'authorizer' ); ?></th>
+							<td><?php $cas->print_select_cas_method( array( 'context' => Helper::NETWORK_CONTEXT ) ); ?></td>
 						</tr>
 						<tr>
 							<th scope="row"><?php esc_html_e( 'CAS server protocol', 'authorizer' ); ?></th>

--- a/src/authorizer/class-ajax-endpoints.php
+++ b/src/authorizer/class-ajax-endpoints.php
@@ -175,6 +175,7 @@ class Ajax_Endpoints extends Singleton {
 			'cas_host',
 			'cas_port',
 			'cas_path',
+			'cas_method',
 			'cas_version',
 			'cas_attr_email',
 			'cas_attr_first_name',

--- a/src/authorizer/class-authentication.php
+++ b/src/authorizer/class-authentication.php
@@ -773,7 +773,7 @@ class Authentication extends Singleton {
 		$cas_version = Options\External\Cas::get_instance()->sanitize_cas_version( $auth_settings['cas_version'] );
 
 		// Set the CAS client configuration.
-		if( strtoupper($auth_settings['cas_method']) === "PROXY" ) {
+		if ( "PROXY" === strtoupper( $auth_settings['cas_method'] ) ) {
 			\phpCAS::proxy( $cas_version, $auth_settings['cas_host'], intval( $auth_settings['cas_port'] ), $auth_settings['cas_path'] );
 		} else {
 			\phpCAS::client( $cas_version, $auth_settings['cas_host'], intval( $auth_settings['cas_port'] ), $auth_settings['cas_path'] );

--- a/src/authorizer/class-authentication.php
+++ b/src/authorizer/class-authentication.php
@@ -773,7 +773,11 @@ class Authentication extends Singleton {
 		$cas_version = Options\External\Cas::get_instance()->sanitize_cas_version( $auth_settings['cas_version'] );
 
 		// Set the CAS client configuration.
-		\phpCAS::client( $cas_version, $auth_settings['cas_host'], intval( $auth_settings['cas_port'] ), $auth_settings['cas_path'] );
+		if( strtoupper($auth_settings['cas_method']) === "PROXY" ) {
+			\phpCAS::proxy( $cas_version, $auth_settings['cas_host'], intval( $auth_settings['cas_port'] ), $auth_settings['cas_path'] );
+		} else {
+			\phpCAS::client( $cas_version, $auth_settings['cas_host'], intval( $auth_settings['cas_port'] ), $auth_settings['cas_path'] );
+		}
 
 		// Allow redirects at the CAS server endpoint (e.g., allow connections
 		// at an old CAS URL that redirects to a newer CAS URL).

--- a/src/authorizer/class-options.php
+++ b/src/authorizer/class-options.php
@@ -186,7 +186,7 @@ class Options extends Singleton {
 				$auth_settings['cas_host']                  = $auth_multisite_settings['cas_host'];
 				$auth_settings['cas_port']                  = $auth_multisite_settings['cas_port'];
 				$auth_settings['cas_path']                  = $auth_multisite_settings['cas_path'];
-				$auth_settings['cas_method']               = $auth_multisite_settings['cas_method'];
+				$auth_settings['cas_method']                = $auth_multisite_settings['cas_method'];
 				$auth_settings['cas_version']               = $auth_multisite_settings['cas_version'];
 				$auth_settings['cas_attr_email']            = $auth_multisite_settings['cas_attr_email'];
 				$auth_settings['cas_attr_first_name']       = $auth_multisite_settings['cas_attr_first_name'];

--- a/src/authorizer/class-options.php
+++ b/src/authorizer/class-options.php
@@ -186,6 +186,7 @@ class Options extends Singleton {
 				$auth_settings['cas_host']                  = $auth_multisite_settings['cas_host'];
 				$auth_settings['cas_port']                  = $auth_multisite_settings['cas_port'];
 				$auth_settings['cas_path']                  = $auth_multisite_settings['cas_path'];
+				$auth_settings['cas_method']               = $auth_multisite_settings['cas_method'];
 				$auth_settings['cas_version']               = $auth_multisite_settings['cas_version'];
 				$auth_settings['cas_attr_email']            = $auth_multisite_settings['cas_attr_email'];
 				$auth_settings['cas_attr_first_name']       = $auth_multisite_settings['cas_attr_first_name'];
@@ -393,6 +394,9 @@ class Options extends Singleton {
 		}
 		if ( ! array_key_exists( 'cas_path', $auth_settings ) ) {
 			$auth_settings['cas_path'] = '';
+		}
+		if ( ! array_key_exists( 'cas_method', $auth_settings ) ) {
+			$auth_settings['cas_method'] = Options\External\Cas::get_instance()->sanitize_cas_method();
 		}
 		if ( ! array_key_exists( 'cas_version', $auth_settings ) ) {
 			$auth_settings['cas_version'] = Options\External\Cas::get_instance()->sanitize_cas_version();
@@ -604,6 +608,9 @@ class Options extends Singleton {
 			}
 			if ( ! array_key_exists( 'cas_path', $auth_multisite_settings ) ) {
 				$auth_multisite_settings['cas_path'] = '';
+			}
+			if ( ! array_key_exists( 'cas_method', $auth_multisite_settings ) ) {
+				$auth_multisite_settings['cas_method'] = Options\External\Cas::get_instance()->sanitize_cas_method();
 			}
 			if ( ! array_key_exists( 'cas_version', $auth_multisite_settings ) ) {
 				$auth_multisite_settings['cas_version'] = Options\External\Cas::get_instance()->sanitize_cas_version();

--- a/src/authorizer/class-updates.php
+++ b/src/authorizer/class-updates.php
@@ -467,6 +467,27 @@ class Updates extends Singleton {
 			$needs_updating = true;
 		}
 
+		// Update: Set default values for newly added cas_method option.
+		$update_if_older_than = 20220818;
+		if ( false === $auth_version || intval( $auth_version ) < $update_if_older_than ) {
+			// Provide default values for any $auth_settings options that don't exist.
+			if ( is_multisite() ) {
+				// phpcs:ignore WordPress.WP.DeprecatedFunctions.wp_get_sitesFound
+				$sites = function_exists( 'get_sites' ) ? get_sites() : wp_get_sites( array( 'limit' => PHP_INT_MAX ) );
+				foreach ( $sites as $site ) {
+					$blog_id = function_exists( 'get_sites' ) ? $site->blog_id : $site['blog_id'];
+					switch_to_blog( $blog_id );
+					$options->set_default_options();
+					restore_current_blog();
+				}
+			} else {
+				$options->set_default_options();
+			}
+			// Update version to reflect this change has been made.
+			$auth_version   = $update_if_older_than;
+			$needs_updating = true;
+		}
+
 		/* phpcs:ignore Squiz.PHP.CommentedOutCode.Found
 		// Update: TEMPLATE
 		$update_if_older_than = YYYYMMDD;

--- a/src/authorizer/options/external/class-cas.php
+++ b/src/authorizer/options/external/class-cas.php
@@ -146,11 +146,15 @@ class Cas extends \Authorizer\Singleton {
 		$option               = 'cas_method';
 		$auth_settings_option = $options->get( $option, Helper::get_context( $args ), 'allow override', 'print overlay' );
 		$auth_settings_option = $this->sanitize_cas_method( $auth_settings_option );
+		$select_options       = array(
+			'CLIENT' => 'Client',
+			'PROXY'  => 'Proxy',
+		);
 
 		// Print option elements.
 		?>
 		<select id="auth_settings_<?php echo esc_attr( $option ); ?>" name="auth_settings[<?php echo esc_attr( $option ); ?>]">
-			<?php foreach ( array('CLIENT'=>'Client', 'PROXY'=>'Proxy') as $method => $label ) : ?>
+			<?php foreach ( $select_options as $method => $label ) : ?>
 					<option value="<?php echo esc_attr( $method ); ?>" <?php selected( $auth_settings_option, $method ); ?>><?php echo esc_html( $label ); ?></option>
 			<?php endforeach; ?>
 		</select>
@@ -184,12 +188,11 @@ class Cas extends \Authorizer\Singleton {
 
 
 	/**
-	 * Validate supplied CAS method. Older versions of Authorizer
-	 * stored custom protocol version strings, so we handle converting those here.
+	 * Validate supplied CAS method.
 	 *
-	 * @param  string $cas_method CAS protocol string.
+	 * @param  string $cas_method CAS method string.
 	 *
-	 * @return string CAS method string.
+	 * @return string             CAS method string 'PROXY' or 'CLIENT' (default).
 	 */
 	public function sanitize_cas_method( $cas_method = '' ) {
 		$cas_methods = array( 'PROXY', 'CLIENT' );
@@ -199,8 +202,8 @@ class Cas extends \Authorizer\Singleton {
 
 		return $cas_method;
 	}
-	
-	
+
+
 	/**
 	 * Validate supplied CAS version against phpCAS. Older versions of Authorizer
 	 * stored custom protocol version strings, so we handle converting those here.

--- a/src/authorizer/options/external/class-cas.php
+++ b/src/authorizer/options/external/class-cas.php
@@ -154,6 +154,7 @@ class Cas extends \Authorizer\Singleton {
 					<option value="<?php echo esc_attr( $method ); ?>" <?php selected( $auth_settings_option, $method ); ?>><?php echo esc_html( $label ); ?></option>
 			<?php endforeach; ?>
 		</select>
+		<p class="description"><small><?php esc_html_e( '"Client" is the most common, but use "Proxy" if your CAS server is behind a proxy server.', 'authorizer' ); ?></small></p>
 		<?php
 	}
 

--- a/src/authorizer/options/external/class-cas.php
+++ b/src/authorizer/options/external/class-cas.php
@@ -192,22 +192,9 @@ class Cas extends \Authorizer\Singleton {
 	 * @return string CAS method string.
 	 */
 	public function sanitize_cas_method( $cas_method = '' ) {
-		if ( ! class_exists( 'phpCAS' ) ) {
-			return '';
-		}
-
-		$cas_methods = ['PROXY', 'CLIENT'];
-		if ( empty( $cas_method ) ) {
-			$cas_method = array_key_last( $cas_methods ); // Should be 'client'.
-		} elseif ( ! in_array( $cas_method, array_keys( $cas_methods ), true ) ) {
-			// Backwards compatibility with constant strings from Authorizer < 3.0.11.
-			if ( 'CLIENT' === $cas_method ) {
-				$cas_method = 'CLIENT';
-			} elseif ( 'PROXY' === $cas_method ) {
-				$cas_method = 'PROXY';
-			} else {
-				$cas_method = array_key_last( $cas_methods );
-			}
+		$cas_methods = array( 'PROXY', 'CLIENT' );
+		if ( empty( $cas_method ) || ! in_array( $cas_method, $cas_methods, true ) ) {
+			$cas_method = array_pop( $cas_methods ); // Default to 'CLIENT'.
 		}
 
 		return $cas_method;


### PR DESCRIPTION
The organization I work for is using your WP Plugin. However, for it to work with our CAS server, we had to change a line of code in the `class-authentication.php` file that dealt with interfacing with a CAS server. Adding this customization prevented us from using the WP plugin update feature because it would overwrite our changes anytime Authorizer was updated.

I'm proposing this pull request that allows for a WP admin to choose how to interface with a CAS server, either over Proxy or using the Client method (see commits). I also added help documentation. These are demonstrated in the screenshots below.  I have a limited understanding/knowledge of Authorizer and how CAS works, but did my best to add this functionality. Please feel free to share feedback as needed.

#### Option shown to WP Admin in the "External" tab of Authorizer:

<img width="507" alt="Screen Shot 2022-08-15 at 13 09 34" src="https://user-images.githubusercontent.com/931107/184710232-aaec0126-42ef-4edb-a5c4-65dd166f2351.png">

#### Help documentation:

<img width="870" alt="Screen Shot 2022-08-15 at 13 10 28" src="https://user-images.githubusercontent.com/931107/184710236-a7a44574-51b5-41fa-80ab-b24bd87a2111.png">

