### PR TITLE
Added Multi-Role implementation

### DIFF
--- a/src/authorizer/class-authorization.php
+++ b/src/authorizer/class-authorization.php
@@ -150,15 +150,14 @@ class Authorization extends Singleton {
 		 * @param array $user_data User data returned from external service.
 		 */
 
+		$add_roles = [];
+		$remove_roles = [];
 		$custom_role_return = apply_filters( 'authorizer_custom_role', $default_role, $user_data );
 		if (is_array($custom_role_return) && count($custom_role_return, 0) == 3)
 			[$approved_role, $add_roles, $remove_roles] = $custom_role_return;
-		else {
+		else 
 			$approved_role = $custom_role_return;
-			$add_roles = [];
-			$remove_roles = [];
-		}
-
+		
 		/**
 		 * Filter whether to automatically approve the currently logging in user
 		 * based on any of their user attributes.
@@ -316,10 +315,9 @@ class Authorization extends Singleton {
 					 * );
 					 */
 					do_action( 'authorizer_user_register', $user, $user_data );
+					// Add Secondary roles to user
 					foreach($add_roles as $role)
 						$user->add_role($role);
-					foreach($remove_roles as $role)
-						$user->remove_role($role);
 					// If multisite, iterate through all sites in the network and add the user
 					// currently logging in to any of them that have the user on the approved list.
 					// Note: this is useful for first-time logins--some users will have access
@@ -403,6 +401,13 @@ class Authorization extends Singleton {
 					if ( $should_update_last_name ) {
 						update_user_meta( $user->ID, 'last_name', $user_data['last_name'] );
 					}
+					// Update User Roles
+					foreach($add_roles as $role)
+						if(!in_array($role, $user->roles))
+							$user->add_role($role);
+					foreach($remove_roles as $role)
+						if(in_array($role, $user->roles))
+							$user->remove_role($role);
 				}
 
 				// If this is multisite, add new user to current blog.

--- a/src/authorizer/class-authorization.php
+++ b/src/authorizer/class-authorization.php
@@ -149,7 +149,15 @@ class Authorization extends Singleton {
 		 * @param bool $role Role of the user currently logging in.
 		 * @param array $user_data User data returned from external service.
 		 */
-		$approved_role = apply_filters( 'authorizer_custom_role', $default_role, $user_data );
+
+		$custom_role_return = apply_filters( 'authorizer_custom_role', $default_role, $user_data );
+		if (is_array($custom_role_return) && count($custom_role_return, 0) == 3)
+			[$approved_role, $add_roles, $remove_roles] = $custom_role_return;
+		else {
+			$approved_role = $custom_role_return;
+			$add_roles = [];
+			$remove_roles = [];
+		}
 
 		/**
 		 * Filter whether to automatically approve the currently logging in user
@@ -308,7 +316,10 @@ class Authorization extends Singleton {
 					 * );
 					 */
 					do_action( 'authorizer_user_register', $user, $user_data );
-
+					foreach($add_roles as $role)
+						$user->add_role($role);
+					foreach($remove_roles as $role)
+						$user->remove_role($role);
 					// If multisite, iterate through all sites in the network and add the user
 					// currently logging in to any of them that have the user on the approved list.
 					// Note: this is useful for first-time logins--some users will have access


### PR DESCRIPTION
Added backward compatible multi-role implementation.  An example of a modified snippet which would take advantage of this is:

```php
function update_authorizer_custom_role( $default_role, $user_data ) {
	// Don't change role for administrators.
	if ( 'administrator' === $default_role ) {
		return $default_role;
	}
	$add_role = [];
	$remove_role = [];
	// Assign custom roles to users.
	if ( isset( $user_data['oauth2_attributes']['groups'] ) ) {
		// Mapping for OAuth groups to WordPress roles. If a user has
		// multiple groups, the first one in the array below takes primary role and all others are assigned as secondary roles.
		$group_to_role_mapping = array(
			'Lead Developer' => 'lead-developer',
			'Developer' => 'developer',
			// Add more mappings here, if needed, in this format:
			// 'uh-grouping' => 'wordpress_role',
		);
		$changedRole = False;
		foreach ( $group_to_role_mapping as $group => $role ) {
			if (
				$group === $user_data['oauth2_attributes']['groups'] ||
				(
					is_array( $user_data['oauth2_attributes']['groups'] ) &&
					array_search( $group, $user_data['oauth2_attributes']['groups'] ) !== false
				)
			) {
				if(!$changedRole) {
					$default_role = $role;
					$changedRole = True;
				}
				else
				array_push($add_role, $role);
			}
			else{
				array_push($remove_role, $role);
			}
		}
	}

	return [$default_role, $add_role, $remove_role];
}
add_filter( 'authorizer_custom_role', 'update_authorizer_custom_role', 10, 2 );
```

Also want to commend you guys for creating this.  I didn't want to get nickled and dimed by miniorange and this works perfectly.  Thank you to both the university and maintainers for creating something awesome!